### PR TITLE
replace (remove|getNum)Children by (remove|getNum)Drawables...

### DIFF
--- a/src/GraphScene.cpp
+++ b/src/GraphScene.cpp
@@ -675,7 +675,7 @@ void GraphScene::updateInDirLine(const lb::Vec3& inDir, int wavelengthIndex)
 
     osg::Geometry* geom = scene_util::createStippledLine(osg::Vec3(), dir,
                                                          osg::Vec4(1.0, 0.0, 0.0, 1.0));
-    inDirGeode_->removeChildren(0, inDirGeode_->getNumChildren());
+    inDirGeode_->removeDrawables(0, inDirGeode_->getNumDrawables());
     inDirGeode_->addDrawable(geom);
 }
 
@@ -714,7 +714,7 @@ void GraphScene::updateInOutDirLine(const lb::Vec3& inDir,
                                     const lb::Vec3& outDir,
                                     int             wavelengthIndex)
 {
-    inOutDirGeode_->removeChildren(0, inOutDirGeode_->getNumChildren());
+    inOutDirGeode_->removeDrawables(0, inOutDirGeode_->getNumDrawables());
 
     if (inDir.isZero() && outDir.isZero()) {
         return;

--- a/src/GraphScene.h
+++ b/src/GraphScene.h
@@ -124,7 +124,7 @@ private:
     void initializeInDirLine();
     void updateInDirLine(const lb::Vec3& inDir, int wavelengthIndex);
     osg::Vec3 modifyDirLineLength(const lb::Vec3& lineDir, int wavelengthIndex);
-    void clearInDirLine() { inDirGeode_->removeChildren(0, inDirGeode_->getNumChildren()); }
+    void clearInDirLine() { inDirGeode_->removeDrawables(0, inDirGeode_->getNumDrawables()); }
 
     void initializeInOutDirLine();
 


### PR DESCRIPTION
 ... to make it build with OSG version 3.2

---

I am still having an issue with osgQt:

```
[ 63%] Building CXX object CMakeFiles/BSDFViewer.dir/src/GraphWidget.cpp.o
In file included from /Users/marko/WC/GIT/BSDFViewer/src/GraphWidget.cpp:9:
/Users/marko/WC/GIT/BSDFViewer/src/GraphWidget.h:16:10: fatal error: 'osgQt/GraphicsWindowQt' file not found
#include <osgQt/GraphicsWindowQt>
         ^
1 error generated.
make[2]: *** [CMakeFiles/BSDFViewer.dir/src/GraphWidget.cpp.o] Error 1
make[1]: *** [CMakeFiles/BSDFViewer.dir/all] Error 2
make: *** [all] Error 2
```

Could be that MacPorts' OSG doesn't build support for qt:

```
$ port contents OpenSceneGraph | grep qt
$
```
