### PR TITLE
tweak CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,10 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 
-set(LIBBSDF_DIR ../libbsdf)
-add_subdirectory(${LIBBSDF_DIR} LibbsdfBin)
+if(NOT LIBBSDF_DIR)
+    set(LIBBSDF_DIR ../libbsdf)
+    add_subdirectory(${LIBBSDF_DIR} LibbsdfBin)
+endif()
 include_directories(${LIBBSDF_DIR}/include)
 
 project(BSDFProcessor)


### PR DESCRIPTION
tweak CMakeLists.txt in order to allow linking with an already installed libbsdf library
